### PR TITLE
Correct argument counting for --just-scripts option

### DIFF
--- a/bin/yumbootstrap
+++ b/bin/yumbootstrap
@@ -260,9 +260,11 @@ def run_post_install_scripts(suite, skip = [], just = []):
       logger.info("skipping %s", script_name)
       continue
     logger.info("running %s", script_name)
-    os.environ['SCRIPT_NAME'] = script_name
-    os.environ['SCRIPT_PATH'] = script[0]
-    sh.run(script, env = suite.environment)
+    script_env = os.environ.copy()
+    script_env['SCRIPT_NAME'] = script_name
+    script_env['SCRIPT_PATH'] = script[0]
+    script_env.update(suite.environment)
+    sh.run(script, env = script_env)
 
 #-----------------------------------------------------------
 

--- a/bin/yumbootstrap
+++ b/bin/yumbootstrap
@@ -40,7 +40,7 @@ expected_nargs = {
   'yum.conf':     (lambda n: n == 2),
   'list_suites':  (lambda n: n == 0),
   'list_scripts': (lambda n: n == 1),
-  'scripts':      (lambda n: n > 1),
+  'scripts':      (lambda n: n >= 1),
   #'download':     [?],
   #'second_stage': [?],
   #'tarball':      [?],


### PR DESCRIPTION
Mistakenly used n > 1 instead of n >=1 for range [1,0xFFFFFFFF].

Signed-off-by: Earl Chew <earl_chew@yahoo.com>