### PR TITLE
Fedora 20,21 & 22 mirror correction, moved to archives.fedoraproject.org

### DIFF
--- a/distros/fedora-20.suite
+++ b/distros/fedora-20.suite
@@ -11,8 +11,8 @@ finalize = scripts/fix_rpmdb.py
 finalize = scripts/clean_yumbootstrap.py
 
 [repositories]
-fedora         = http://download.fedoraproject.org/pub/fedora/linux/releases/20/Everything/$basearch/os/
-fedora-updates = http://download.fedoraproject.org/pub/fedora/linux/updates/20/$basearch/
+fedora         = http://archives.fedoraproject.org/pub/archive/fedora/linux/releases/20/Everything/$basearch/os/
+fedora-updates = http://archives.fedoraproject.org/pub/archive/fedora/linux/updates/20/$basearch/
 
 [environment]
 #PYTHONPATH=...

--- a/distros/fedora-21.suite
+++ b/distros/fedora-21.suite
@@ -11,8 +11,8 @@ finalize = scripts/fix_rpmdb.py
 finalize = scripts/clean_yumbootstrap.py
 
 [repositories]
-fedora         = http://download.fedoraproject.org/pub/fedora/linux/releases/21/Everything/$basearch/os/
-fedora-updates = http://download.fedoraproject.org/pub/fedora/linux/updates/21/$basearch/
+fedora         = http://archives.fedoraproject.org/pub/archive/fedora/linux/releases/21/Everything/$basearch/os/
+fedora-updates = http://archives.fedoraproject.org/pub/archive/fedora/linux/updates/21/$basearch/
 
 [environment]
 #PYTHONPATH=...

--- a/distros/fedora-22.suite
+++ b/distros/fedora-22.suite
@@ -11,8 +11,8 @@ finalize = scripts/fix_rpmdb.py
 finalize = scripts/clean_yumbootstrap.py
 
 [repositories]
-fedora         = http://download.fedoraproject.org/pub/fedora/linux/releases/22/Everything/$basearch/os/
-fedora-updates = http://download.fedoraproject.org/pub/fedora/linux/updates/22/$basearch/
+fedora         = http://archives.fedoraproject.org/pub/archive/fedora/linux/releases/22/Everything/$basearch/os/
+fedora-updates = http://archives.fedoraproject.org/pub/archive/fedora/linux/updates/22/$basearch/
 
 [environment]
 #PYTHONPATH=...


### PR DESCRIPTION
Hi @dozzie I corrected the old .repo files to use the archive mirrors since these versions have been archived.